### PR TITLE
Removing Cassandra Embedded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,20 @@
+sudo: required
+
 language: scala
+
+services:
+  - docker
+
 scala:
-   - 2.12.2
+  - 2.12.2
+
+before_install:
+  make cassandra/run
+
+after_success:
+  make cassandra/clean
+
 script:
-- sbt clean test
+  - sbt clean test
+
 jdk: oraclejdk8
-sudo: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+cassandra/run:
+	- docker run --name cassandra-phantom -d -e CASSANDRA_BROADCAST_ADDRESS=localhost -p 9042:9042 cassandra:latest
+
+cassandra/clean:
+	- docker rm -f cassandra-phantom
+
+cassandra: cassandra/clean cassandra/run

--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@
 
 This project will give you the idea on how to design your cassandra tables in scala using the [phantom-dsl](https://github.com/outworkers/phantom). My inspiration is to bring here a more real world example based on this library.
 
-## Features
-
-Across the code, you will find the following features:
-
 ### Connect to a secure Cassandra Cluster
 
-In the class ```Connector``` you will find two connectors:
-- Connect to a Cassandra Cluster somewhere
-- Connect using an embedded Cassandra (this one is for tests only running through ```sbt test```, checkout the phantom plugin)
+In the class ```Connector``` you will find a connector that connects to a Cassandra Cluster
 
 ### Set Consistency Level
 
@@ -25,17 +19,39 @@ This is maybe the main goal of this project, showing to you how to handle multip
 - Songs
 - SongsByArtist
 
-You will find how to insert and delete on both tables
+You will find how to insert and delete on both tables.
 
-### Testing using an embedded Cassandra in memory
+### Requirements
 
-Using ```sbt test``` you can run the tests without having any previously Cassandra instalation up and running.
+This project uses docker in order to get up and running a cassandra instance.
+
+### Testing
+
+We are using the official cassandra docker image to setup a simple host.
+
+For convenience we are using Makefile where you will find the following commands:
+
+    - make cassandra/run
+        This command starts a cassandra instance in your localhost and name it as cassandra-phantom.
+        You can see it using the `docker ps` command.
+        
+    - make cassandra/clean 
+        It removes the existing image from your docker.
+        
+    - make cassandra 
+        Runs both command in sequence.
+
+If you don't know Makefile, please check the links below on the Resources section.
+
+After that you can test using `sbt test`.
 
 ## Resources
 
 - [http://docs.datastax.com/en/cql/3.1/cql/ddl/dataModelingApproach.html](http://docs.datastax.com/en/cql/3.1/cql/ddl/dataModelingApproach.html)
 - [https://github.com/outworkers/phantom](https://github.com/outworkers/phantom)
-- [https://medium.com/@foundev/cassandra-batch-loading-without-the-batch-keyword-40f00e35e23e](https://medium.com/@foundev/cassandra-batch-loading-without-the-batch-keyword-40f00e35e23e)
+- [https://store.docker.com/images/cassandra](https://store.docker.com/images/cassandra)
+- [https://github.com/docker-library/cassandra](https://github.com/docker-library/cassandra)
+- [https://en.wikipedia.org/wiki/Makefile](https://en.wikipedia.org/wiki/Makefile)
 
 ### Thanks
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,3 @@ libraryDependencies ++= Seq(
   "com.outworkers"  %%  "util-testing"      % Versions.util % Test,
   "org.scalatest"   %%  "scalatest"         % Versions.scalatest % Test
 )
-
-PhantomSbtPlugin.projectSettings
-
-phantomCassandraTimeout := Some(60000)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,5 +8,3 @@ def websudosPattern = {
 resolvers ++= Seq(
   Resolver.url("Maven ivy Websudos", url(Resolver.DefaultMavenRepositoryRoot))(websudosPattern)
 )
-
-addSbtPlugin("com.websudos" %% "phantom-sbt" % "1.27.0")

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -6,6 +6,4 @@
 cassandra {
   host = ["localhost"]
   keyspace = "test"
-  username = "cassandra"
-  password = "cassandra"
 }

--- a/src/main/scala/com/cassandra/phantom/modeling/connector/Connector.scala
+++ b/src/main/scala/com/cassandra/phantom/modeling/connector/Connector.scala
@@ -1,6 +1,6 @@
 package com.cassandra.phantom.modeling.connector
 
-import com.outworkers.phantom.connectors.{CassandraConnection, ContactPoint, ContactPoints}
+import com.outworkers.phantom.connectors.{CassandraConnection, ContactPoints}
 import com.typesafe.config.ConfigFactory
 
 import scala.collection.JavaConverters._
@@ -10,19 +10,18 @@ object Connector {
 
   private val hosts = config.getStringList("cassandra.host").asScala
   private val keyspace = config.getString("cassandra.keyspace")
-  private val username = config.getString("cassandra.username")
-  private val password = config.getString("cassandra.password")
 
   /**
-    * Create a connector with the ability to connects to
-    * multiple hosts in a secured cluster
+    * Create a connector with the ability to connects to multiple hosts in a cluster
+    *
+    * If you need to connect to a secure cluster, use:
+    * {{{
+    * ContactPoints(hosts)
+    *   .withClusterBuilder(_.withCredentials(username, password))
+    *   .keySpace(keyspace)
+    * }}}
+    *
     */
-  lazy val connector: CassandraConnection = ContactPoints(hosts)
-    .withClusterBuilder(_.withCredentials(username, password))
-    .keySpace(keyspace)
+  lazy val connector: CassandraConnection = ContactPoints(hosts).keySpace(keyspace)
 
-  /**
-    * Create an embedded connector, testing purposes only
-    */
-  lazy val testConnector: CassandraConnection = ContactPoint.embedded.noHeartbeat().keySpace("my_app_test")
 }

--- a/src/main/scala/com/cassandra/phantom/modeling/database/SongsDatabase.scala
+++ b/src/main/scala/com/cassandra/phantom/modeling/database/SongsDatabase.scala
@@ -12,7 +12,6 @@ import scala.concurrent.Future
   * This is our Database object that wraps our two existing tables,
   * giving the ability to receive different connectors
   * for example: One for production and other for testing
-  *
   */
 class SongsDatabase(override val connector: CassandraConnection) extends Database[SongsDatabase](connector) {
   object SongsModel extends SongsModel with connector.Connector
@@ -46,12 +45,6 @@ class SongsDatabase(override val connector: CassandraConnection) extends Databas
 }
 
 /**
-  * This is the production database, it connects to a secured cluster with multiple contact points
+  * This is the database, it connects to a cluster with multiple contact points
   */
-object ProductionDb extends SongsDatabase(connector)
-
-/**
-  * Thanks for the Phantom plugin, you can start an embedded cassandra in memory,
-  * in this case we are using it for tests
-  */
-object EmbeddedDb extends SongsDatabase(testConnector)
+object Database extends SongsDatabase(connector)

--- a/src/test/scala/com/cassandra/phantom/modeling/test/service/SongsTest.scala
+++ b/src/test/scala/com/cassandra/phantom/modeling/test/service/SongsTest.scala
@@ -1,6 +1,6 @@
 package com.cassandra.phantom.modeling.test.service
 
-import com.cassandra.phantom.modeling.database.EmbeddedDb
+import com.cassandra.phantom.modeling.database.Database
 import com.cassandra.phantom.modeling.entity.Song
 import com.cassandra.phantom.modeling.test.utils.{CassandraSpec, SongsGenerator}
 import com.outworkers.phantom.dsl._
@@ -99,7 +99,7 @@ class SongsTest extends CassandraSpec with SongsGenerator {
     * @param song the song to be inserted
     * @return a [[Future]] of [[ResultSet]]
     */
-  private def store(song: Song): Future[ResultSet] = EmbeddedDb.saveOrUpdate(song)
+  private def store(song: Song): Future[ResultSet] = Database.saveOrUpdate(song)
 
   /**
     * Utility method to delete into both tables
@@ -107,5 +107,5 @@ class SongsTest extends CassandraSpec with SongsGenerator {
     * @param song the song to be deleted
     * @return a [[Future]] of [[ResultSet]]
     */
-  private def drop(song: Song) = EmbeddedDb.delete(song)
+  private def drop(song: Song) = Database.delete(song)
 }

--- a/src/test/scala/com/cassandra/phantom/modeling/test/utils/CassandraSpec.scala
+++ b/src/test/scala/com/cassandra/phantom/modeling/test/utils/CassandraSpec.scala
@@ -1,12 +1,12 @@
 package com.cassandra.phantom.modeling.test.utils
 
-import com.cassandra.phantom.modeling.database.{EmbeddedDb, SongsDatabase}
+import com.cassandra.phantom.modeling.database.{Database, SongsDatabase}
 import com.outworkers.phantom.database.DatabaseProvider
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
 trait SongsDbProvider extends DatabaseProvider[SongsDatabase] {
-  override def database: SongsDatabase = EmbeddedDb
+  override def database: SongsDatabase = Database
 }
 
 trait CassandraSpec extends FlatSpec


### PR DESCRIPTION
In this commit, the cassandra embedded version is completely removed, since it has already been deprecated by phantom-dsl itself.

We then introduce docker, using the official cassandra image in order to get up and running a cassandra instance,
where you can safely run the tests.

It also contains a Makefile, to help you create and remove the cassandra instance without explicity type it everytime,
you just need a docker instalation up and running on your machine.

This commit solves https://github.com/thiagoandrade6/cassandra-phantom/issues/16