### PR TITLE
Use logged batches for increased consistency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,12 @@ name := "cassandra-phantom"
 
 version := "1.0"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
 
 lazy val Versions = new {
-  val phantom = "2.12.1"
+  val phantom = "2.14.5"
   val util = "0.30.1"
   val scalatest = "3.0.1"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
 lazy val Versions = new {
   val phantom = "2.14.5"
   val util = "0.30.1"
-  val scalatest = "3.0.1"
+  val scalatest = "3.0.4"
 }
 
 resolvers ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 0.13.16


### PR DESCRIPTION
This is done in the case where data is being inserted into two tables. If an insert to one table succeeds and an insert to another one fails then the logged batch will take care of rolling back the first insert. 

This is a [good use case for batching](https://docs.datastax.com/en/cql/3.3/cql/cql_using/useBatchGoodExample.html) because it falls under the category of being a Multiple partition logged batch.

Closes https://github.com/thiagoandrade6/cassandra-phantom/issues/18

Upgraded Phantom, ScalaTest and Scala